### PR TITLE
Replace FixupInstall.cmake with EXPORT_NAME property

### DIFF
--- a/cmakelib/FixupInstall.cmake.in
+++ b/cmakelib/FixupInstall.cmake.in
@@ -1,6 +1,0 @@
-file(READ "@CMAKE_BINARY_DIR@/CMakeFiles/Export/@CMAKE_INSTALL_LIBDIR@/cmake/@PROJECT_NAME@/@PROJECT_NAME@Exports.cmake" exportfile1)
-string(REGEX REPLACE "[^ :\"(;]+::([^_]+)_(hl|sl|dl)" "\\1::\\2" exportfile2 "${exportfile1}")
-if(NOT exportfile1 STREQUAL exportfile2)
-  file(WRITE "@CMAKE_BINARY_DIR@/CMakeFiles/Export/@CMAKE_INSTALL_LIBDIR@/cmake/@PROJECT_NAME@/@PROJECT_NAME@Exports.cmake" "${exportfile2}")
-  file(WRITE "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@PROJECT_NAME@/@PROJECT_NAME@Exports.cmake" "${exportfile2}")
-endif()

--- a/cmakelib/QuickCppLibMakeExport.cmake
+++ b/cmakelib/QuickCppLibMakeExport.cmake
@@ -2,9 +2,3 @@ install(EXPORT ${PROJECT_NAME}Exports
   NAMESPACE ${PROJECT_NAME}::
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
-configure_file(
-  "${CMAKE_CURRENT_LIST_DIR}/FixupInstall.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}FixupInstall.cmake"
-  @ONLY
-)
-install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}FixupInstall.cmake")

--- a/cmakelib/QuickCppLibMakeInstall.cmake
+++ b/cmakelib/QuickCppLibMakeInstall.cmake
@@ -16,6 +16,7 @@ if(TARGET ${PROJECT_NAME}_hl)
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
+    set_property(TARGET ${PROJECT_NAME}_hl PROPERTY EXPORT_NAME hl)
 endif()
 if(TARGET ${PROJECT_NAME}_sl)
     install(TARGETS ${PROJECT_NAME}_sl
@@ -24,6 +25,7 @@ if(TARGET ${PROJECT_NAME}_sl)
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
+    set_property(TARGET ${PROJECT_NAME}_sl PROPERTY EXPORT_NAME sl)
 endif()
 if(TARGET ${PROJECT_NAME}_dl)
     install(TARGETS ${PROJECT_NAME}_dl
@@ -32,6 +34,7 @@ if(TARGET ${PROJECT_NAME}_dl)
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
+    set_property(TARGET ${PROJECT_NAME}_dl PROPERTY EXPORT_NAME dl)
 endif()
 
 # Create and install a find package file


### PR DESCRIPTION
While trying to package llfio and co. for vcpkg I noticed that some exported CMake targets were broken for some because the regular expression in `FixupInstall.cmake.in` is too liberal. But there is an easier way to change the name using CMake's `EXPORT_NAME` property (supported since 3.0).