### PR TITLE
Fix erroneous GitHub profile link in the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ CTest dashboard: http://my.cdash.org/index.php?project=QuickCppLib
 
 Documentation: https://ned14.github.io/quickcpplib/
 
-Common library for most of https://github.com/ned14's open source libraries. Automates away hassle for build, sanitising, linting, documentation, super building, dependencies, modules, single include generation, and lack of later C++ facilities in C++ 14.
+Common library for most of [https://github.com/ned14](https://github.com/ned14)'s open source libraries. Automates away hassle for build, sanitising, linting, documentation, super building, dependencies, modules, single include generation, and lack of later C++ facilities in C++ 14.
 
 ## Requirements:
 - GCC 6 or later (Linux)


### PR DESCRIPTION
Hi,

it was such a small thing, yet quite annoying:

**Issue**

The link to your (ned14) GitHub profile was wrong in the README.

**Cause**

The Markdown parser accidentally picked up `'s`  as part of the link.

**Fix**

Instead of relying on the GFM autolink feature, wrapped it in an explicit link.