### PR TITLE
Do not perform a compiler check in outer superbuild

### DIFF
--- a/cmakelib/DownloadBuildInstall.cmake.in
+++ b/cmakelib/DownloadBuildInstall.cmake.in
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(DownloadBuildInstall)
+project(DownloadBuildInstall NONE)
 include(ExternalProject)
 ExternalProject_Add(@DBI_NAME@
   PREFIX "@DBI_DESTINATION@/repo"


### PR DESCRIPTION
This fixes cases where the environment does not provide a usable C compiler without extra CMake arguments, e.g. CMAKE_TOOLCHAIN_FILE. This is particularly the case with embedded targets. 