### PR TITLE
make automatic download of dependency working even if CMAKE_SYSROOT is set

### DIFF
--- a/cmakelib/QuickCppLibUtils.cmake
+++ b/cmakelib/QuickCppLibUtils.cmake
@@ -369,7 +369,12 @@ function(find_quickcpplib_library libraryname)
         set(FINDLIB_LOCAL_PATH "${QUICKCPPLIB_ROOT_BINARY_DIR}/${libraryname}")
         set(${libraryname}_FOUND TRUE)
       else()
-        find_package(${libraryname} CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${QUICKCPPLIB_ROOT_BINARY_DIR}/${libraryname}")
+        # Normally, the following ${libraryname}_DIR would not be needed if
+        # PATHS "${QUICKCPPLIB_ROOT_BINARY_DIR}/${libraryname}" were provided.
+        # However, when CMAKE_SYSROOT is set, the paths provided by the PATHS option are assumed to be system paths
+        # even when they are in the build directory, and get rewritten into the sysroot.
+        set(${libraryname}_DIR "${QUICKCPPLIB_ROOT_BINARY_DIR}/${libraryname}/lib/cmake/${libraryname}")
+        find_package(${libraryname} CONFIG REQUIRED NO_DEFAULT_PATH)
       endif()
     endif()
     


### PR DESCRIPTION
One more hidden CMake magic to wrangle with. The documentation of [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure) is not very explicit, but the page on  [`CMAKE_SYSROOT`](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html#cmake-sysroot) hints that it's presence causes search-paths to be rewritten. In this case, the just built dependency is not found. The documentation is not clear, but `HINTS` might potentially be exempt of path rewriting, contrary to `PATHS`. However, in this bugfix, I propose to give no search paths at all and just set `${libraryname}_DIR` beforehand directly.