### PR TITLE
Adjust coroutine test promise type

### DIFF
--- a/cmakelib/QuickCppLibUtils.cmake
+++ b/cmakelib/QuickCppLibUtils.cmake
@@ -565,8 +565,8 @@ public:
   {
     resumable get_return_object() { return {}; }
     auto initial_suspend() { return suspend_never(); }
-    auto final_suspend() { return suspend_never(); }
-    int return_value(int x) { return x; }
+    auto final_suspend() noexcept { return suspend_never(); }
+    void return_value(int) { }
     void unhandled_exception() {}
   };
   bool resume() { return true; }


### PR DESCRIPTION
- promise.return_value() must be void
- promise.final_suspend() must be noexcept

Avoids rejecting coroutine support for compilers that enforce these rules.