### PR TITLE
Add /alternatename:main for ARM64EC

### DIFF
--- a/include/quickcpplib/boost/test/unit_test.hpp
+++ b/include/quickcpplib/boost/test/unit_test.hpp
@@ -663,8 +663,10 @@ extern inline int quickcpplib_unit_testing_main(int argc, const char* const argv
   int result = QUICKCPPLIB_BOOST_UNIT_TEST_RUN_TESTS(argc, argv);
   return result;
 }
-#if(defined(__x86_64__) || defined(_M_X64)) || (defined(__aarch64__) || defined(_M_ARM64))
+#if(defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))) || (defined(__aarch64__) || defined(_M_ARM64))
 #pragma comment(linker, "/alternatename:main=?quickcpplib_unit_testing_main@@YAHHQEBQEBD@Z")
+#elif defined(_M_ARM64EC)
+#pragma comment(linker, "/alternatename:main=?quickcpplib_unit_testing_main@@$$hYAHHQEBQEBD@Z")
 #elif defined(__x86__) || defined(_M_IX86) || defined(__i386__)
 #pragma comment(linker, "/alternatename:_main=?quickcpplib_unit_testing_main@@YAHHQBQBD@Z")
 #elif defined(__arm__) || defined(_M_ARM)


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/cpp/build/arm64ec-windows-abi-conventions?view=msvc-170#arm64ec-function-name-decoration, the ARM64EC name decoration is different from the x64 and ARM64, so we need to update the /alternatename:main for ARM64EC.