### PR TITLE
QuickCppLibSetupProject.cmake: Fix safe-stack check

### DIFF
--- a/cmakelib/QuickCppLibSetupProject.cmake
+++ b/cmakelib/QuickCppLibSetupProject.cmake
@@ -183,11 +183,11 @@ if(NOT MSVC)
   endforeach()
 
   # This fellow probably ought to be compiled into every executable
-  set(CMAKE_REQUIRED_FLAGS "-fsanitize=safestack")
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=safe-stack")
   check_cxx_source_compiles("int main() { return 0; }" COMPILER_HAS_SAFESTACK)
   if(COMPILER_HAS_SAFESTACK)
-    set(SAFESTACK_COMPILE_FLAGS -fsanitize=safestack)
-    set(SAFESTACKLINK_FLAGS -fsanitize=safestack)
+    set(SAFESTACK_COMPILE_FLAGS -fsanitize=safe-stack)
+    set(SAFESTACKLINK_FLAGS -fsanitize=safe-stack)
   endif()
   # This fellow probably should just always be turned on period
   set(CMAKE_REQUIRED_FLAGS "-fstack-protector-strong")


### PR DESCRIPTION
This commit fixes the typo in `-fsanitize=safe-stack` flag. The flag value is `safe-stack` and not `safestack` as it was used in the project.

See:
```
root@6e0967fe1290:/# clang --version
Debian clang version 15.0.1-++20220921072637+b73d2c8c720a-1~exp1~20220921072648.64
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-15/bin
root@6e0967fe1290:/# cat a.c
int main() {}
root@6e0967fe1290:/# clang -fsanitize=safe-stack a.c
root@6e0967fe1290:/# clang -fsanitize=safestack a.c
clang: error: unsupported argument 'safestack' to option '-fsanitize='
```