### PR TITLE
Allow disabling of docs target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ list(FIND CMAKE_MODULE_PATH "quickcpplib" quickcpplib_idx)
 if(${quickcpplib_idx} GREATER -1)
   return()
 endif()
+option(QUICKCPPLIB_ENABLE_DOXYGEN_DOCS_BUILD_SUPPORT "Enable doxygen docs build support" ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmakelib")
 include(QuickCppLibRequireOutOfSourceBuild)
 include(QuickCppLibUtils)
@@ -38,8 +39,11 @@ if (QUICKCPPLIB_REQUIRE_CXX17 OR QUICKCPPLIB_REQUIRE_CXX20)
 endif()
 # Make an interface only library so dependent CMakeLists can bring in this header-only library
 include(QuickCppLibMakeHeaderOnlyLibrary)
-# Make a docs target
-include(QuickCppLibMakeDoxygen)
+
+if(QUICKCPPLIB_ENABLE_DOXYGEN_DOCS_BUILD_SUPPORT)
+  # Make a docs target
+  include(QuickCppLibMakeDoxygen)
+endif()
 
 # Set the standard definitions for these libraries and bring in the all_* helper functions
 include(QuickCppLibApplyDefaultDefinitions)


### PR DESCRIPTION
When we do not have doxygen installed and do not want to build docs, this gives out unnecessary warning in cmake:
```
WARNING: Doxygen not found, so disabling quickcpplib_docs target quickcpplib/cmakelib/QuickCppLibMakeDoxygen.cmake:4 (indented_message) quickcpplib/CMakeLists.txt:42 (include)
```

This allows disabling the creation of quickcpplib_docs target if not needed.

The original behavior is preserved, the docs target is created and built by default.