### PR TITLE
fix: Properly cast `void *` to `timer_t`

### DIFF
--- a/include/quickcpplib/detail/impl/signal_guard.ipp
+++ b/include/quickcpplib/detail/impl/signal_guard.ipp
@@ -1613,7 +1613,7 @@ linker,                                                                         
         _threadh = nullptr;
 #else
 #ifndef __APPLE__
-        if(-1 == ::timer_delete(_timerid))
+        if(-1 == ::timer_delete(static_cast<timer_t>(_timerid)))
         {
           throw std::system_error(errno, std::system_category());
         }


### PR DESCRIPTION
Some OS like FreeBSD define `timer_t` as a pointer to some forward declared struct type which requires an explicit downcast.

Fix #42 