### PR TITLE
Use [[nodiscard]] on GCC when concepts are not used

### DIFF
--- a/include/quickcpplib/config.hpp
+++ b/include/quickcpplib/config.hpp
@@ -235,7 +235,7 @@ extern "C" void _mm_pause();
 #endif
 #endif
 #ifndef QUICKCPPLIB_NODISCARD
-#if QUICKCPPLIB_HAS_CPP_ATTRIBUTE(nodiscard, 201700) && (!defined(__GNUC__) || __cpp_concepts >= 202000L /* -fconcepts-ts and [[nodiscard]] don't mix on GCC   \
+#if QUICKCPPLIB_HAS_CPP_ATTRIBUTE(nodiscard, 201700) && (!defined(__GNUC__) || !defined(__cpp_concepts) || __cpp_concepts >= 202000L /* -fconcepts-ts and [[nodiscard]] don't mix on GCC   \
                                                                                                           */)
 #define QUICKCPPLIB_NODISCARD [[nodiscard]]
 #elif defined(__clang__)  // deliberately not GCC


### PR DESCRIPTION
On GCC with `--std=c++17` and no `-fconcepts` or `-fconcepts-ts` flags, the `__cpp_concepts` is not defined so we can use `[[nodiscard]]`.