### PR TITLE
Edit generate_gdb_printer.py

### DIFF
--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -74,7 +74,7 @@ bottom_matter = f"""
 with open(printers_header, "wt") as header:
     header.write(top_matter)
     for line in script_contents:
-        if line == '\n':
+        if line.isspace():
             header.write("\n")
             continue
         line2 = repr(line)[1:-1]

--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -6,12 +6,24 @@
 import os, sys
 import datetime
 
-if len(sys.argv) < 3:
-  print(f"{sys.argv[0]} <output.h> <input.py> [macro name]")
+if len(sys.argv) < 3 or len(sys.argv) > 5:
+  print(f"{sys.argv[0]} <output.h> <input.py> [protection_macro [disabling_macro]]")
   sys.exit(1)
 
-printers_script = sys.argv[2]
 printers_header = sys.argv[1]
+printers_script = sys.argv[2]
+
+if len(sys.argv) > 3:
+    protection_macro = sys.argv[3]
+else:
+    protection_macro = printers_header.lstrip("/").replace("/", "_").replace(".", "_").upper()
+
+if len(sys.argv) > 4:
+    disable_macro = sys.argv[4]
+elif "INLINE" in protection_macro:
+    disable_macro = protection_macro.replace("INLINE", "DISABLE_INLINE")
+else:
+    disable_macro = protection_macro + "_DISABLE"
 
 timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S")
 
@@ -29,10 +41,6 @@ while True:
         del script_contents[0]
     else:
         break
-
-protection_macro = sys.argv[3] if len(sys.argv) > 3 else (os.path.splitext(printers_header)[0].upper() + "_INLINE_H")
-disable_macro = sys.argv[3].replace("INLINE", "DISABLE_INLINE") if len(sys.argv) > 3 else (os.path.splitext(printers_header)[0].upper() + "_DISABLE_INLINE")
-
 
 top_matter = f"""{copyright_message}
 

--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -54,13 +54,13 @@ top_matter = f"""{copyright_message}
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \\".debug_gdb_scripts\\", \\"MS\\",@progbits,1\\n"
-        ".byte 4 /* Python Text */\\n"
-        ".ascii \\"gdb.inlined-script\\\\n\\"\\n"
+__asm__(R"(.pushsection ".debug_gdb_scripts", "MS",@progbits,1
+.byte 4 /* Python Text */
+.ascii "gdb.inlined-script\\n"
 """
-bottom_matter = f"""
-        ".byte 0\\n"
-        ".popsection\\n");
+bottom_matter = f""".byte 0
+.popsection
+)");
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -75,10 +75,8 @@ with open(printers_header, "wt") as header:
     header.write(top_matter)
     for line in script_contents:
         if line.isspace():
-            header.write("\n")
             continue
-        line2 = repr(line)[1:-1]
-        line3 = repr(line2)[1:-1]
-        print(f"{line} => {line2} => {line3}")
-        header.write(f"""        ".ascii \\"{line3}\\"\\n"\n""")
+        line2 = repr(line)[1:-1] # Change newlines into escaped newlines
+        line3 = line2.replace("\"", "\\\"")
+        header.write(f""".ascii "{line3}"\n""")
     header.write(bottom_matter)

--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -55,7 +55,7 @@ top_matter = f"""{copyright_message}
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
 __asm__(R"(.pushsection ".debug_gdb_scripts", "MS",@progbits,1
-.byte 4 /* Python Text */
+.ascii "\\4{protection_macro}"
 .ascii "gdb.inlined-script\\n"
 """
 bottom_matter = f""".byte 0

--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -43,7 +43,6 @@ while True:
         break
 
 top_matter = f"""{copyright_message}
-
 // Generated on {timestamp}
 
 #ifndef {protection_macro}

--- a/scripts/generate_gdb_printer.py
+++ b/scripts/generate_gdb_printer.py
@@ -25,7 +25,7 @@ elif "INLINE" in protection_macro:
 else:
     disable_macro = protection_macro + "_DISABLE"
 
-timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S")
+timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
 # Grab the entire script
 with open(printers_script, "rt") as script:


### PR DESCRIPTION
This script is functioning properly for my work on the Boost.Unordered pretty-printers, and the Boost.Interprocess pretty-printer for `offset_ptr`.

Personally, I choose to use the script like this:
```
generate_gdb_printer.py path/to/boost/libs/unordered/include/boost/unordered/unordered_printers.hpp path/to/boost/libs/unordered/extra/boost_unordered_printers.py BOOST_UNORDERED_UNORDERED_PRINTERS_HPP BOOST_UNORDERED_DISABLE_INLINE_PRINTERS
```

Importantly, this script now works with executables containing multiple inline pretty-printer scripts by giving each one a different name. As well, this script now uses raw string literals in the C++ output, for better readability.